### PR TITLE
Moved stop_service dnsmasq

### DIFF
--- a/automated install/basic-install.sh
+++ b/automated install/basic-install.sh
@@ -1984,7 +1984,6 @@ main() {
     # Create directory for Pi-hole storage
     mkdir -p /etc/pihole/
 
-    stop_service dnsmasq
     if [[ "${INSTALL_WEB}" == true ]]; then
       stop_service lighttpd
     fi
@@ -2002,6 +2001,9 @@ main() {
     setLogging
     # Clone/Update the repos
     clone_or_update_repos
+
+    #Stop DNSMASQ if running so we can install
+    stop_service dnsmasq
 
     # Install packages used by the Pi-hole
     if [[ "${INSTALL_WEB}" == true ]]; then


### PR DESCRIPTION
stop_service dnsmasq runs before the install scripts are pulled from Git, so if the machine we're installing on is already running dnsmasq we can't resolve github.com and therefore can't download the scripts.

**By submitting this pull request, I confirm the following:** `{please fill any appropriate checkboxes, e.g: [X]}`

`{Please ensure that your pull request is for the 'development' branch!}`

- [X] I have read and understood the [contributors guide](https://github.com/pi-hole/pi-hole/blob/master/CONTRIBUTING.md), as well as this entire template.
- [X] I have made only one major change in my proposed changes.
- [X] I have commented my proposed changes within the code.
- [X] I have tested my proposed changes, and have included unit tests where possible.
- [X] I am willing to help maintain this change if there are issues with it later.
- [X] I give this submission freely and claim no ownership.
- [X] It is compatible with the [EUPL 1.2 license](https://opensource.org/licenses/EUPL-1.1)
- [X] I have squashed any insignificant commits. ([`git rebase`](http://gitready.com/advanced/2009/02/10/squashing-commits-with-rebase.html))
- [X] I have Signed Off all commits. ([`git commit --signoff`](https://git-scm.com/docs/git-commit#git-commit---signoff))

---

**What does this PR aim to accomplish?:**

 Fix issue with installer when DNSMASQ is already running.     stop_service dnsmasq runs prior to the install scripts being downloaded from Github. If DNSMASQ is already running and our resolver is 127.0.0.1, stopping the service prevents the scripts being pulled from Git.

**How does this PR accomplish the above?:**

Moves stop_service dnsmasq to after the script download.

**What documentation changes (if any) are needed to support this PR?:**

None